### PR TITLE
Prefer loaded association (Support eager-loading)

### DIFF
--- a/lib/metabolical.rb
+++ b/lib/metabolical.rb
@@ -18,7 +18,7 @@ module Metabolical
         has_many :metas, :as => :metabolized, :class_name => 'Metabolical::MetaDatum' do
           def [](key)
             owner = (self.respond_to?(:proxy_association) ? self.proxy_association.owner : self.proxy_owner)
-            (owner.metas.loaded? && owner.metas.detect{|m| m.key == key} } || find_by(key: key) || owner.metas.build(:key => key)
+            (owner.metas.loaded? && owner.metas.detect{|m| m.key == key} ) || find_by(key: key) || owner.metas.build(:key => key)
           end
           
           def []=(key, data)

--- a/lib/metabolical.rb
+++ b/lib/metabolical.rb
@@ -18,7 +18,11 @@ module Metabolical
         has_many :metas, :as => :metabolized, :class_name => 'Metabolical::MetaDatum' do
           def [](key)
             owner = (self.respond_to?(:proxy_association) ? self.proxy_association.owner : self.proxy_owner)
-            find_by_key(key) || owner.metas.detect{|m| m.key == key} || owner.metas.build(:key => key)
+            if owner.metas.loaded?
+              owner.metas.detect{|m| m.key == key}
+            else
+              find_by_key(key) || owner.metas.detect{|m| m.key == key} || owner.metas.build(:key => key)
+            end
           end
           
           def []=(key, data)

--- a/lib/metabolical.rb
+++ b/lib/metabolical.rb
@@ -18,11 +18,7 @@ module Metabolical
         has_many :metas, :as => :metabolized, :class_name => 'Metabolical::MetaDatum' do
           def [](key)
             owner = (self.respond_to?(:proxy_association) ? self.proxy_association.owner : self.proxy_owner)
-            if owner.metas.loaded?
-              owner.metas.detect{|m| m.key == key}
-            else
-              find_by_key(key) || owner.metas.detect{|m| m.key == key} || owner.metas.build(:key => key)
-            end
+            (owner.metas.loaded? && owner.metas.detect{|m| m.key == key} } || find_by(key: key) || owner.metas.build(:key => key)
           end
           
           def []=(key, data)


### PR DESCRIPTION
Currently, if we try to eager load metas, it will still try to query individual records.
This change will check to see if the `:metas` collection is loaded and look there first.

Example usage:
```ruby
User.where(conditions).includes(:metas) do |user|
  user.metas["active"]
end
```

I am not sure which Rails versions support the `loaded?` method.