### PR TITLE
Explicitly load when building

### DIFF
--- a/lib/metabolical.rb
+++ b/lib/metabolical.rb
@@ -3,11 +3,11 @@ require 'metabolical/scopes'
 
 module Metabolical
   class Error < StandardError; end
-  
+
   def self.included(klass)
     klass.extend ClassMethods
-  end  
-  
+  end
+
   module ClassMethods
     def metabolize!
       if self.respond_to?(:named_scope)
@@ -20,9 +20,9 @@ module Metabolical
         has_many :metas, :as => :metabolized, :class_name => 'Metabolical::MetaDatum' do
           def [](key)
             owner = (self.respond_to?(:proxy_association) ? self.proxy_association.owner : self.proxy_owner)
-            (owner.metas.loaded? && owner.metas.detect{|m| m.key == key} ) || find_by(key: key) || owner.metas.build(:key => key)
+            (owner.metas.loaded? && owner.metas.detect { |m| m.key == key }) || find_by(key: key) || owner.metas.load.build(:key => key)
           end
-          
+
           def []=(key, data)
             owner = (self.respond_to?(:proxy_association) ? self.proxy_association.owner : self.proxy_owner)
             meta = self[key]
@@ -32,8 +32,8 @@ module Metabolical
           end
         end
       end
-      
+
     end
   end
-    
+
 end

--- a/test/metabolical_test.rb
+++ b/test/metabolical_test.rb
@@ -23,6 +23,21 @@ describe Metabolical do
         @user.metas['foo'] = 'bar'
         assert_equal 'bar', @user.metas['foo'].data
       end
+
+      it "should be able to assign multiple metas before saving and retrieving them after save" do
+        @user.metas['foo'] = 'bar'
+        @user.metas['baz'] = 'fuu'
+        @user.save
+        assert_equal 'bar', @user.metas['foo'].data
+        assert_equal 'fuu', @user.metas['baz'].data
+      end
+
+      it "should be able to assign multiple metas before saving and retrieving them before save" do
+        @user.metas['foo'] = 'bar'
+        @user.metas['baz'] = 'fuu'
+        assert_equal 'bar', @user.metas['foo'].data
+        assert_equal 'fuu', @user.metas['baz'].data
+      end
     end
     
     describe "saved record" do


### PR DESCRIPTION
The previous change made it optional for the branch `owner.metas.detect` to execute, which was implicitly loading the `metas` collection by calling the `detect` method. 

This created an edge case where assigning a new Meta would be put into an unloaded collection and discarded when trying to access it again.

This PR reverts the behavior to act more like the original behavior (loading the collection).